### PR TITLE
fix(mkdir): create directory with proper permission

### DIFF
--- a/lua/fundo/manager.lua
+++ b/lua/fundo/manager.lua
@@ -117,7 +117,7 @@ function Manager:initialize()
     self.initialized = true
     self.archivesDir = path.normalize(config.archives_dir)
     self.limitArchivesSize = config.limit_archives_size
-    fs.mkdirSync(self.archivesDir, 0)
+    fn.mkdir(self.archivesDir, 'p')
     self.undos = {}
     self.lastScannedtime = 0
     self.mutex = mutex:new()


### PR DESCRIPTION
Previously `fundo` will initialize a directory with wrong permission, which is not accessible by both the user and the plugin itself, causing the plugin not working at all.

![image](https://user-images.githubusercontent.com/23206205/222891877-daea66e8-18fd-4e42-9f54-0be937d3b19c.png)

After the patch:

![image](https://user-images.githubusercontent.com/23206205/222891925-c21295f9-806c-4c65-bb06-656064041212.png)
