### PR TITLE
refactor: use non-deprecated form of `vim.validate`

### DIFF
--- a/lua/fundo/config.lua
+++ b/lua/fundo/config.lua
@@ -13,10 +13,8 @@ local function init()
     local fundo = require('fundo')
     ---@type FundoConfig
     Config = vim.tbl_deep_extend('keep', fundo._config or {}, def)
-    vim.validate({
-        archives_dir = {Config.archives_dir, 'string'},
-        limit_archives_size = {Config.limit_archives_size, 'number'}
-    })
+    vim.validate('archives_dir', Config.archives_dir, 'string')
+    vim.validate('limit_archives_size', Config.limit_archives_size, 'number')
     Config.archives_dir = vim.fn.expand(Config.archives_dir)
     fundo._config = nil
 end

--- a/lua/fundo/lib/debounce.lua
+++ b/lua/fundo/lib/debounce.lua
@@ -15,8 +15,9 @@ local Debounce = {}
 ---@param leading? boolean
 ---@return FundoDebounce
 function Debounce:new(fn, wait, leading)
-    vim.validate({fn = {fn, 'function'}, wait = {wait, 'number'},
-                  leading = {leading, 'boolean', true}})
+    vim.validate('fn', fn, 'function')
+    vim.validate('wait', wait, 'number')
+    vim.validate('leading', leading, 'boolean', true)
     local o = setmetatable({}, self)
     o.timer = nil
     o.fn = vim.schedule_wrap(fn)


### PR DESCRIPTION
Fixes #13. I'm not very familiar with the codebase, so can't test properly - but I'm fairly certain this should be a one-to-one match.